### PR TITLE
Add Override for WorldEdit

### DIFF
--- a/src/main/java/com/lovetropics/perms/LTPermissions.java
+++ b/src/main/java/com/lovetropics/perms/LTPermissions.java
@@ -68,6 +68,7 @@ public class LTPermissions {
     public static final RoleOverrideType<Boolean> MUTE = RoleOverrideType.register("mute", Codec.BOOL);
     public static final RoleOverrideType<Boolean> COMMAND_FEEDBACK = RoleOverrideType.register("command_feedback", Codec.BOOL);
     public static final RoleOverrideType<Boolean> BYPASS_WHITELIST = RoleOverrideType.register("bypass_whitelist", Codec.BOOL);
+    public static final RoleOverrideType<Boolean> WORLDEDIT_ALLOWED = RoleOverrideType.register("worldedit_allowed", Codec.BOOL);
 
     public static final RoleOverrideType<Waypoint.Icon> WAYPOINT_ICON = RoleOverrideType.register("waypoint_icon", Waypoint.Icon.CODEC)
             .withChangeListener(player -> {

--- a/src/main/java/com/lovetropics/perms/mixin/compact/WorldEditNeoForgePermissionsProviderMixin.java
+++ b/src/main/java/com/lovetropics/perms/mixin/compact/WorldEditNeoForgePermissionsProviderMixin.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(targets = "com.sk89q.worldedit.neoforge.NeoForgePermissionsProvider$VanillaPermissionsProvider")
 public class WorldEditNeoForgePermissionsProviderMixin {
     @Inject(method = "hasPermission", at = @At("HEAD"), cancellable = true)
-    private void load(ServerPlayer player, String permission, CallbackInfoReturnable<Boolean> cir) {
+    private void hasPermission(ServerPlayer player, String permission, CallbackInfoReturnable<Boolean> cir) {
         PlayerRoleSet roles = PlayerRoleManager.get().peekRoles(player.getUUID());
         if (roles.overrides().test(LTPermissions.WORLDEDIT_ALLOWED)) {
             cir.setReturnValue(true);

--- a/src/main/java/com/lovetropics/perms/mixin/compact/WorldEditNeoForgePermissionsProviderMixin.java
+++ b/src/main/java/com/lovetropics/perms/mixin/compact/WorldEditNeoForgePermissionsProviderMixin.java
@@ -1,0 +1,22 @@
+package com.lovetropics.perms.mixin.compact;
+
+import com.lovetropics.perms.LTPermissions;
+import com.lovetropics.perms.store.PlayerRoleManager;
+import com.lovetropics.perms.store.PlayerRoleSet;
+import net.minecraft.server.level.ServerPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+//https://github.com/EngineHub/WorldEdit/blob/version/7.3.x/worldedit-neoforge/src/main/java/com/sk89q/worldedit/neoforge/NeoForgePermissionsProvider.java#L32
+@Mixin(targets = "com.sk89q.worldedit.neoforge.NeoForgePermissionsProvider$VanillaPermissionsProvider")
+public class WorldEditNeoForgePermissionsProviderMixin {
+    @Inject(method = "hasPermission", at = @At("HEAD"), cancellable = true)
+    private void load(ServerPlayer player, String permission, CallbackInfoReturnable<Boolean> cir) {
+        PlayerRoleSet roles = PlayerRoleManager.get().peekRoles(player.getUUID());
+        if (roles.overrides().test(LTPermissions.WORLDEDIT_ALLOWED)) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/resources/ltpermissions.mixins.json
+++ b/src/main/resources/ltpermissions.mixins.json
@@ -9,6 +9,7 @@
     "PlayerListMixin",
     "ReloadableServerResourcesMixin",
     "LivingEntityMixin",
+    "compact.WorldEditNeoForgePermissionsProviderMixin",
     "rule.CraftingMenuMixin",
     "rule.LecternMenuMixin",
     "rule.SignBlockMixin"


### PR DESCRIPTION
Simple Mixin to change world edit perms checks.

Don't think we need access to change specify world edit perms, as we can just use the command overrides for that 